### PR TITLE
Require retained MQTT updates before sleeping

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ to change the MQTT topic prefix.
 
 - The device boots, prevents deep sleep, and waits for MQTT to connect.
 - When connected it resets the state bitmask, republishes retained topics, and
-  schedules a sleep once all required messages have been seen.
+  waits for the retained online-lock, OpenGarage status, and door-state
+  messages before scheduling deep sleep.
 - The WS2812 LED uses the following colors:
   - **Green** – Door open and OpenGarage online
   - **Blue** – Door open while OpenGarage is offline

--- a/config/ogrgb.yaml
+++ b/config/ogrgb.yaml
@@ -230,14 +230,38 @@ script:
   - id: maybe_finish_and_sleep
     mode: restart
     then:
-      - lambda: 'if (!id(ready)) return;'
       - if:
           condition:
-            lambda: 'return !id(online_lock);'
+            lambda: 'return id(ready);'
           then:
-            - deep_sleep.allow: deep_sleep_1
-          else:
-            - logger.log: "Online lock active, remaining awake."
+            - if:
+                condition:
+                  lambda: 'return (id(seen_mask) & 0x07) == 0x07;'
+                then:
+                  - if:
+                      condition:
+                        lambda: 'return !id(online_lock);'
+                      then:
+                        - deep_sleep.allow: deep_sleep_1
+                      else:
+                        - logger.log: "Online lock active, remaining awake."
+                else:
+                  - lambda: |-
+                      uint8_t missing = static_cast<uint8_t>(0x07 & ~id(seen_mask));
+                      std::string topics;
+                      if (missing & 0x01) {
+                        if (!topics.empty()) topics += ", ";
+                        topics += "online lock";
+                      }
+                      if (missing & 0x02) {
+                        if (!topics.empty()) topics += ", ";
+                        topics += "OpenGarage status";
+                      }
+                      if (missing & 0x04) {
+                        if (!topics.empty()) topics += ", ";
+                        topics += "door state";
+                      }
+                      ESP_LOGW("Sleep", "Awaiting retained MQTT updates for: %s", topics.c_str());
 
   - id: online_lock_timeout_arm
     mode: restart


### PR DESCRIPTION
## Summary
- gate deep sleep until all retained MQTT topics have been received and add logging for missing topics
- document the retained-topic requirement in the behavior summary

## Testing
- esphome version *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d5a5ebf8688324b737ab96f90b1a77